### PR TITLE
Update build time dependency numpy>=2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "numpy>=1.21.0"]
+requires = ["setuptools>=42", "wheel", "numpy>=2.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]


### PR DESCRIPTION
The build time dependency numpy>=2.0 is needed for keeping compatibility for numpy 1.x **and** 2.x

Because of the current build time dependency, at the moment lapjv cannot be used with projects using numpy 2.x

See https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice for more information.