### PR TITLE
Fix github CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -53,6 +53,10 @@ jobs:
     steps:
     - name: actions/checkout
       uses: actions/checkout@v3
+    - name: actions/setup-python@v4
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
     - name: actions/cache pip
       uses: actions/cache@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        cibw_python: [ "cp38-*", "cp39-*", "cp310-*", "cp311-*" ]
+        cibw_python: [ "cp39-*", "cp310-*", "cp311-*" ]
         cibw_arch: [ "auto64" ]
 
     defaults:


### PR DESCRIPTION
The current github CI is broken and it is preventing to upload new versions of lapjv to pypi.

After introducing https://github.com/src-d/lapjv/pull/84 lapjv is now incompatible with Cpython 3.8 (because there is no numpy >= 2.0 that has been released for Cpython 3.8), this is why I removed it from the cibuildwheel list. I don't think it's a huge deal as python 3.8 will reach EOL in just a few months (see https://devguide.python.org/versions/), and older versions of lapjv will still be out there for folks that need python 3.8 support.